### PR TITLE
Add country-specific processors and validators for Panama and Peru

### DIFF
--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -1,0 +1,68 @@
+from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
+from fastapi.responses import JSONResponse
+from pathlib import Path
+import os
+import json
+
+from services.document_processor import DocumentProcessor
+from services.webhook import WebhookService
+from config.settings import API_KEY
+from utils.logger import logger
+
+router = APIRouter()
+webhook_service = WebhookService()
+
+
+def get_document_processor() -> DocumentProcessor:
+    """Función de inyección de dependencias para obtener la instancia de DocumentProcessor."""
+    return DocumentProcessor(api_key=API_KEY)
+
+
+@router.post("/upload-document/")
+async def upload_document(
+    file: UploadFile = File(...), 
+    document_processor: DocumentProcessor = Depends(get_document_processor)
+):
+    """Endpoint para la carga y procesamiento de documentos (imágenes o PDF)."""
+    # Guardar el archivo en un directorio temporal
+    tmp_dir = Path("/tmp")
+    tmp_dir.mkdir(exist_ok=True)
+    file_path = tmp_dir / file.filename
+
+    # Validar el tipo de archivo
+    file_ext = file_path.suffix.lower()
+    if file_ext not in ['.jpg', '.jpeg', '.png', '.pdf']:
+        logger.error(f"Unsupported file type: {file_ext}")
+        webhook_service.send_to_webhook(f"Unsupported file type: {file_ext}")
+        raise HTTPException(status_code=415, detail="Unsupported file type. Only PDFs and images are allowed.")
+
+    try:
+        with open(file_path, "wb") as buffer:
+            buffer.write(await file.read())
+    except Exception as e:
+        logger.error(f"Error saving file: {e}")
+        webhook_service.send_to_webhook(f"Error saving file: {e}")
+        raise HTTPException(status_code=500, detail=f"Error saving file: {e}")
+
+    try:
+        response = document_processor.process_document(str(file_path))
+        response_json = json.loads(response)  # Convertir la cadena JSON a un objeto JSON
+    except Exception as e:
+        logger.error(f"Error processing document: {e}")
+        webhook_service.send_to_webhook(f"Error processing document: {e}")
+        raise HTTPException(status_code=500, detail=f"Error processing document: {e}")
+
+    # Eliminar el archivo temporal después del procesamiento
+    try:
+        os.remove(file_path)
+    except Exception as e:
+        logger.warning(f"Error deleting file: {e}")
+        # Se podría registrar el error, pero no interrumpe la respuesta
+        pass
+
+    return JSONResponse(content=response_json)
+
+
+@router.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+import uvicorn
+
+from api.endpoints import router as document_router
+
+app = FastAPI(
+    title="Mistral API",
+    version="1.0.0",
+    description="API para procesamiento de documentos utilizando Mistral para OCR y generación de respuestas estructuradas."
+)
+
+# Incluir los endpoints definidos en endpoints.py con un prefijo para la versión o agrupación
+app.include_router(document_router, prefix="/api")
+
+
+if __name__ == "__main__":
+    from config.settings import DEBUG, HOST, PORT
+    # Ejecutar la aplicación con Uvicorn
+    uvicorn.run("api.main:app", host=HOST, port=PORT, reload=True, debug=DEBUG)

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,0 +1,137 @@
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    # Clave API para autenticación con Mistral
+    API_KEY: str
+    
+    # Otras configuraciones generales
+    DEBUG: bool
+    HOST: str
+    PORT: int
+    WEBHOOK_URL: str
+    TEMPLATE: str = """
+    Eres un experto en facturación y debes extraer información del documento en un JSON estructurado. 
+    Asegúrate de respetar el formato y no inventar datos. Si algún dato no está en el documento, deja el campo vacío.
+
+    ### **Reglas Generales**
+    1. Extrae los datos según el formato y las convenciones del país correspondiente.
+    2. Si el documento pertenece a un país específico, sigue las reglas locales de ese país (ver sección de reglas por país).
+    3. No inventes valores. Si un campo no está presente, déjalo vacío.
+    4. Sigue estrictamente los formatos especificados.
+    5. Traduce al inglés cualquier texto que no esté en este idioma, excepto nombres propios y direcciones.
+    6. Todas las fechas deben estandarizarse al formato YYYY-MM-DD. Si solo tienes mes y año, usa YYYY-MM-01.
+
+    ### **Reglas de Formato Comunes**
+    - **Tax Identification Number**: IMPORTANTE: Extraer el número EXACTO que aparece en el documento, SIN caracteres especiales como guiones o espacios. Nunca uses valores predeterminados o ejemplos.
+    - **Tax Document Type**: Extraer el acrónimo del tipo de documento de identidad (Ejemplo: "Cédula de Ciudadanía" → "CC").
+    - **Verification Digit**: Extraer solo el número (Ejemplo: "1").
+    - **Company Name Formatting**: Mantener el formato tal como está en el documento.
+    - **Economic Activity Code**: Adaptar según reglas específicas del país.
+    - **Business Responsibilities**: Traducir al inglés las responsabilidades y resumirlas en una lista clara y concisa.
+    - **Document Type**: Extraer el acrónimo del tipo de documento de identidad (Ejemplo: "Cédula de Ciudadanía" → "CC").
+    - **Document Number**: Extraer solo el número (Ejemplo: "1143835336").
+    - **fiscal_document**: Un documento fiscal es ÚNICAMENTE aquel que identifica oficialmente a una empresa o persona natural ante las autoridades tributarias (como un RUT, RUC, CUIT, etc.). Los recibos de compra, facturas de venta, cotizaciones, órdenes de compra y similares NO son documentos fiscales. Responder con `true` solo si el documento es un certificado oficial de identificación tributaria o registro mercantil.
+
+    ### **Reglas por País**
+    #### Colombia:
+    - **Tax Office**: "Dirección de Impuestos y Aduanas Nacionales".
+    - **Document Types**: Es el tipo de documento de identificaion tributaria "NIT", "CC".
+    - **Economic Activity Code**: Código de 4 dígitos exactos.
+    - **Tax Identification Number**: Extraer el numero de identificacion tributaria SIN caracteres especiales como guiones o espacios. Por ejemplo, si en el documento aparece "xxx-xxx-xxx", extraer solo "xxxxxxxxx". Nunca uses este valor como predeterminado.
+    - **fiscal_document**: Es `true` SIEMPRE que el documento sea un formulario RUT (Registro Único Tributario) o certificado de Cámara de Comercio, lo que se puede identificar por la presencia de un NIT, un dígito de verificación, y la mención de "DIAN" o "Dirección de Impuestos y Aduanas Nacionales". Cualquier documento que contenga estos elementos es un documento fiscal oficial y debe marcarse como `true`. Facturas, recibos y otros comprobantes de transacciones comerciales son `false`.
+
+    #### Panamá:
+    - **Tax Office**: "Dirección General de Comercio Interior".
+    - **Document Types**: "RUC", "CC".
+    - **Tax Identification Number**: Mantener el formato original con guiones (Ejemplo: "8-881-744") pero guardarlo sin guiones en el JSON (Ejemplo: "8881744").
+    - **Economic Activity Code**: Usar solo los primeros 4 dígitos si tiene más.
+    - **Verification Digit**: Extraer solo si está explícitamente indicado como dígito verificador.
+    - **fiscal_document**: CRÍTICO: Un documento panameño ES SIEMPRE un documento fiscal cuando contiene: (1) un número de identificación con formato panameño (con guiones como "3-753-2443"), (2) nombre de un establecimiento comercial o actividad económica, y (3) cualquier mención a trámites oficiales, PanamaEmprende o Aviso de Operación. Si un documento contiene estos tres elementos, DEBE marcarse como `true` sin excepción. Ignorar esta regla es un error crítico de clasificación. Los documentos panameños que mencionen "Operation Notice", declaraciones juradas sobre establecimientos o "PanamaEmprende" son SIEMPRE documentos fiscales.
+
+    #### Argentina:
+    - **Tax Office**: "Administración Federal de Ingresos Públicos".
+    - **Document Types**: "CUIT", "CUIL", "DNI".
+    - **Tax Identification Number**: Extraer SIN caracteres especiales como guiones (Ejemplo original: "33-70707631-9" → resultado: "33707076319").
+    - **Verification Digit**: Usar el último dígito del CUIT/CUIL (Ejemplo: "9" del "33-70707631-9").
+    - **Economic Activity Code**: Mantener el código original en el formato que aparezca.
+    - **Dates**: Convertir formatos como "03-2000" a "2000-03-01".
+    - **fiscal_document**: IMPORTANTE: Un documento que contiene un número CUIT/CUIL y el título "ADMINISTRACIÓN FEDERAL DE INGRESOS PÚBLICOS" o "AFIP" es SIEMPRE un documento fiscal. Debe marcarse como `true` si muestra un CUIT/CUIL acompañado del nombre de una empresa u organización y cualquier referencia a la AFIP o constancia de inscripción. NUNCA marques como `false` un documento que muestre un CUIT/CUIL, datos de la empresa y el nombre de AFIP. Si ves estos elementos juntos, es definitivamente `true`.
+
+    #### Perú:
+    - **Tax Office**: "Superintendencia Nacional de Aduanas y de Administración Tributaria".
+    - **Document Types**: "RUC", "DNI".
+    - **Tax Identification Number**: RUC de 11 dígitos sin espacios.
+    - **Economic Activity Code**: Código CIIU de 4 dígitos.
+    - **fiscal_document**: Es `true` ÚNICAMENTE si el documento es una Ficha RUC o documento oficial de SUNAT. Facturas, recibos y otros comprobantes son `false`.
+
+    #### Otros Países:
+    - Si el país no está listado, aplica las **Reglas Generales** y extrae los datos disponibles respetando el formato JSON esperado.
+
+    ### **Formato JSON esperado**
+    {
+        "fiscal_document": "Booleano que indica si el documento es un documento fiscal.",
+        "tax_information": {
+            "tax_document_type": "Tipo de documento de identidad.",
+            "tax_identification_number": "Número de identificación tributaria SIN caracteres especiales.",
+            "verification_digit": "Dígito verificador del NIT.",
+            "tax_office": "Nombre de la oficina de impuestos."
+        },
+        "company_information": {
+            "legal_name": "Nombre legal exacto de la empresa.",
+            "commercial_name": "Nombre comercial si existe, de lo contrario vacío.",
+            "abbreviation": "Sigla si aplica, de lo contrario vacío.",
+            "taxpayer_type": "Traducir a inglés.",
+            "economic_activity": {
+                "primary": {
+                    "code": "Código de actividad económica según país.",
+                    "start_date": "Fecha de inicio de la actividad económica primaria en formato YYYY-MM-DD."
+                },
+                "secondary": {
+                    "code": "Código de actividad económica secundaria si existe.",
+                    "start_date": "Fecha de inicio de la actividad económica secundaria en formato YYYY-MM-DD."
+                }
+            }
+        },
+        "legal_representative": {
+            "first_name": "Nombre con solo la primera letra en mayúscula.",
+            "last_name": "Apellidos con la primera letra en mayúscula.",
+            "document_type": "Acrónimo del tipo de documento de identidad.",
+            "document_number": "Número del documento de identidad.",
+            "representation_start_date": "Fecha en formato YYYY-MM-DD."
+        },
+        "location": {
+            "country": "Nombre del país con solo la primera letra en mayúscula.",
+            "state": "Departamento o estado con solo la primera letra en mayúscula.",
+            "city": "Ciudad con solo la primera letra en mayúscula.",
+            "address": "Dirección exacta.",
+            "postal_code": "Código postal.",
+            "email": "Correo electrónico de contacto.",
+            "phone_1": "Número de teléfono sin espacios ni caracteres especiales.",
+            "phone_2": "Número secundario si aplica."
+        },
+        "business_classification": {
+            "responsibilities": "Lista de responsabilidades traducidas a inglés."
+        },
+        "registration": {
+            "registration_date": "Fecha en formato YYYY-MM-DD.",
+            "last_update": "Fecha en formato YYYY-MM-DD."
+        }
+    }
+    """
+
+    class Config:
+        # Permite la carga de variables de entorno desde un archivo .env
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+settings = Settings()
+
+# Exportar la variable API_KEY para que sea fácilmente accesible
+API_KEY = settings.API_KEY
+DEBUG = settings.DEBUG
+HOST = settings.HOST
+PORT = settings.PORT
+TEMPLATE = settings.TEMPLATE
+WEBHOOK_URL = settings.WEBHOOK_URL

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+mistralai == 1.5.2
+fastapi
+uvicorn
+python-multipart
+pydantic-settings

--- a/services/chat_processor.py
+++ b/services/chat_processor.py
@@ -1,0 +1,148 @@
+from typing import Any, Dict, List
+import json
+from mistralai.models import ImageURLChunk, TextChunk
+
+from config.settings import TEMPLATE
+from utils.logger import logger
+
+
+class ChatProcessor:
+    def __init__(self, client: Any):
+        """
+        Inicializa el procesador de chat con una instancia del cliente de Mistral.
+        
+        :param client: Instancia del cliente Mistral, ya configurado con la clave API.
+        """
+        self.client = client
+
+    def get_structured_response_image(self, base64_data_url: str, ocr_markdown: str) -> str:
+        """
+        Genera una respuesta estructurada en JSON para imágenes a partir del OCR obtenido.
+
+        :param base64_data_url: Imagen codificada en base64 en formato data URL.
+        :param ocr_markdown: Texto obtenido del OCR en formato markdown.
+        :return: Cadena JSON con la respuesta estructurada.
+        """
+        # Definición de la plantilla JSON para la respuesta
+        template = TEMPLATE
+        messages: List[Dict] = [
+            {
+                "role": "user",
+                "content": [
+                    ImageURLChunk(image_url=base64_data_url),
+                    TextChunk(
+                        text=(
+                            f"This is image's OCR in markdown:\n\n{ocr_markdown}\n\n"
+                            "IMPORTANTE: Debes devolver SIEMPRE un JSON válido con la siguiente estructura. "
+                            "Si algún campo no está presente en el documento, déjalo como cadena vacía pero manteniendo "
+                            "la estructura intacta.\n\n"
+                            
+                            "DETECCIÓN DE DOCUMENTOS FISCALES: Analiza cuidadosamente cada país según estas reglas:\n\n"
+                            
+                            "1. COLOMBIA: Un documento colombiano ES un documento fiscal si contiene UNO DE ESTOS elementos: "
+                            "(a) Menciona 'RUT' o 'Registro Único Tributario' en cualquier parte del documento, O "
+                            "(b) Contiene un NIT junto con un dígito de verificación, O "
+                            "(c) Contiene una referencia a la DIAN. "
+                            "Si cualquiera de estos elementos está presente, el documento es fiscal (`true`).\n\n"
+                            
+                            "2. PANAMÁ: Un documento panameño ES un documento fiscal cuando contiene: "
+                            "(a) Un número de identificación con guiones (como '3-753-2443'), Y "
+                            "(b) Menciona un establecimiento comercial o actividades económicas, Y "
+                            "(c) Contiene referencias a PanamaEmprende o Aviso de Operación.\n\n"
+                            
+                            "3. ARGENTINA: Un documento argentino ES un documento fiscal cuando contiene: "
+                            "(a) Un número CUIT/CUIL (como '33-70707631-9'), Y "
+                            "(b) Menciona una empresa u organización, Y "
+                            "(c) Hace referencia a la AFIP.\n\n"
+                            
+                            "IMPORTANTE: No exijas que se cumplan TODAS las condiciones para Colombia, con UNA es suficiente.\n\n"
+                            
+                            f"{template}"
+                        )
+                    ),
+                ],
+            }
+        ]
+
+        chat_response = self.client.chat.complete(
+            model="pixtral-12b-latest",
+            messages=messages,
+            response_format={"type": "json_object"},
+            temperature=0,
+        )
+
+        # Verificar si la respuesta es un JSON válido
+        try:
+            response_content = chat_response.choices[0].message.content
+            json.loads(response_content)  # Intentar cargar como JSON
+        except json.JSONDecodeError:
+            logger.error("La respuesta del modelo no es un JSON válido")
+            raise ValueError("La respuesta del modelo no es un JSON válido")
+        
+        return chat_response.choices[0].message.content
+
+    def get_structured_response_pdf(self, document_url: str) -> str:
+        """
+        Genera una respuesta estructurada en JSON para documentos PDF a partir de su URL firmado.
+
+        :param document_url: URL firmado del documento PDF.
+        :return: Cadena JSON con la respuesta estructurada.
+        """
+        template = TEMPLATE
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "document_url",
+                        "document_url": document_url
+                    },
+                    {
+                        "type": "text", 
+                        "text": "DETECCIÓN DE DOCUMENTOS FISCALES: Analiza cuidadosamente cada país según estas reglas:\n\n"
+                            
+                            "1. COLOMBIA: Un documento colombiano ES un documento fiscal si contiene UNO DE ESTOS elementos: "
+                            "(a) Menciona 'RUT' o 'Registro Único Tributario' en cualquier parte del documento, O "
+                            "(b) Contiene un NIT junto con un dígito de verificación, O "
+                            "(c) Contiene una referencia a la DIAN. "
+                            "Si cualquiera de estos elementos está presente, el documento es fiscal (`true`).\n\n"
+                            
+                            "2. PANAMÁ: Un documento panameño ES un documento fiscal cuando contiene: "
+                            "(a) Un número de identificación con guiones (como '3-753-2443'), Y "
+                            "(b) Menciona un establecimiento comercial o actividades económicas, Y "
+                            "(c) Contiene referencias a PanamaEmprende o Aviso de Operación.\n\n"
+                            
+                            "3. ARGENTINA: Un documento argentino ES un documento fiscal cuando contiene: "
+                            "(a) Un número CUIT/CUIL (como '33-70707631-9'), Y "
+                            "(b) Menciona una empresa u organización, Y "
+                            "(c) Hace referencia a la AFIP.\n\n"
+                            
+                            "IMPORTANTE: No exijas que se cumplan TODAS las condiciones para Colombia, con UNA es suficiente."
+                    },
+                    {
+                        "type": "text",
+                        "text": "Puedes devolver un json estructurado con la siguiente estructura"
+                    },
+                    {
+                        "type": "text",
+                        "text": template
+                    }
+                ]
+            }
+        ]
+
+        chat_response = self.client.chat.complete(
+            model="pixtral-12b-latest",
+            messages=messages,
+            response_format={"type": "json_object"},
+            temperature=0,
+        )
+
+        # Verificar si la respuesta es un JSON válido
+        try:
+            response_content = chat_response.choices[0].message.content
+            json.loads(response_content)  # Intentar cargar como JSON
+        except json.JSONDecodeError:
+            logger.error("La respuesta del modelo no es un JSON válido")
+            raise ValueError("La respuesta del modelo no es un JSON válido")
+        return chat_response.choices[0].message.content

--- a/services/document_processor.py
+++ b/services/document_processor.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+from mistralai import Mistral
+from services.ocr_processor import OCRProcessor
+from services.chat_processor import ChatProcessor
+from utils.post_processing.validators.fiscal_validator import FiscalDocumentValidator
+from utils.post_processing.processor import ResponsePostProcessor
+from utils.file_encoder import FileEncoder
+from utils.logger import logger
+
+
+class DocumentProcessor:
+    def __init__(self, api_key: str):
+        """Inicializa el procesador de documentos creando instancias del cliente Mistral, OCRProcessor y ChatProcessor."""
+        self.client = Mistral(api_key=api_key)
+        self.ocr_processor = OCRProcessor(self.client)
+        self.chat_processor = ChatProcessor(self.client)
+        self.fiscal_validator = FiscalDocumentValidator()
+        self.post_processor = ResponsePostProcessor()
+
+    def process_document(self, file_path: str) -> str:
+        """Procesa un documento (imagen o PDF) basado en su extensión y retorna una respuesta estructurada en formato JSON.
+
+        :param file_path: Ruta del archivo a procesar.
+        :return: Respuesta estructurada en formato JSON.
+        :raises ValueError: Si el tipo de archivo no es soportado o falla la codificación de la imagen.
+        """
+        file_ext = Path(file_path).suffix.lower()
+        ocr_markdown = ""
+
+        if file_ext in ['.jpg', '.jpeg', '.png', '.webp', '.gif']:
+            ocr_markdown = self.ocr_processor.process_image(file_path)
+            base64_image = FileEncoder.encode_image(file_path)
+            if base64_image is None:
+                logger.error(f"Error al codificar la imagen: {file_path}")
+                raise ValueError(f"Error al codificar la imagen: {file_path}")
+            base64_data_url = f"data:image/jpeg;base64,{base64_image}"
+            structured_response = self.chat_processor.get_structured_response_image(base64_data_url, ocr_markdown)
+        elif file_ext == ".pdf":
+            document_url = self.ocr_processor.process_pdf(file_path)
+            structured_response = self.chat_processor.get_structured_response_pdf(document_url)
+        else:
+            logger.error(f"Tipo de archivo no soportado: {file_ext}")
+            raise ValueError("Tipo de archivo no soportado. Solo se permiten PDFs e imágenes (JPG, JPEG, PNG, WEBP, GIF).")
+
+        logger.info(f"Respuesta estructurada generada: {structured_response}")
+
+        # Validar el documento fiscal
+        try:
+            structured_response = self.fiscal_validator.validate(structured_response, ocr_markdown)
+        except Exception as e:
+            logger.error(f"Error al validar el documento fiscal: {e}")
+            raise ValueError(f"Error al validar el documento fiscal: {e}")
+        
+        # Post-procesar la respuesta estructurada
+        try:
+            structured_response = self.post_processor.process_response(structured_response, ocr_markdown)
+        except Exception as e:
+            logger.error(f"Error al post-procesar la respuesta estructurada: {e}")
+            raise ValueError(f"Error al post-procesar la respuesta estructurada: {e}")
+        
+        logger.info(f"Documento validado y post procesado: {structured_response}")
+        return structured_response

--- a/services/ocr_processor.py
+++ b/services/ocr_processor.py
@@ -1,0 +1,79 @@
+import base64
+import logging
+from pathlib import Path
+from mistralai.models import ImageURLChunk
+from utils.logger import logger
+
+class OCRProcessor:
+    def __init__(self, client):
+        """Inicializa el procesador de OCR con una instancia del cliente Mistral.
+
+        :param client: Instancia del cliente Mistral, configurado con la clave API.
+        """
+        self.client = client
+
+    def process_image(self, image_path: str) -> str:
+        """Procesa una imagen utilizando OCR y retorna el resultado en formato markdown.
+
+        :param image_path: Ruta del archivo de imagen.
+        :return: Texto en formato markdown extraído de la imagen.
+        :raises FileNotFoundError: Si el archivo no existe.
+        :raises Exception: Para otros errores durante el procesamiento.
+        """
+        image_file = Path(image_path)
+        if not image_file.is_file():
+            logger.error(f"Archivo no encontrado: {image_path}")
+            raise FileNotFoundError(f"Archivo no encontrado: {image_path}")
+
+        try:
+            encoded = base64.b64encode(image_file.read_bytes()).decode('utf-8')
+            base64_data_url = f"data:image/jpeg;base64,{encoded}"
+            image_response = self.client.ocr.process(
+                document=ImageURLChunk(image_url=base64_data_url),
+                model="mistral-ocr-latest"
+            )
+            return image_response.pages[0].markdown
+        except Exception as e:
+            logger.error(f"Error al procesar la imagen {image_path}: {e}")
+            raise e
+
+    def process_pdf(self, pdf_path: str) -> str:
+        """Procesa un documento PDF utilizando OCR y retorna la URL firmada del documento procesado.
+
+        :param pdf_path: Ruta del archivo PDF.
+        :return: URL firmada del documento PDF.
+        :raises FileNotFoundError: Si el archivo no existe.
+        :raises Exception: Para otros errores durante el procesamiento.
+        """
+        pdf_file = Path(pdf_path)
+        if not pdf_file.is_file():
+            logger.error(f"Archivo no encontrado: {pdf_path}")
+            raise FileNotFoundError(f"Archivo no encontrado: {pdf_path}")
+
+        try:
+            with open(pdf_file, "rb") as file_content:
+                uploaded_file = self.client.files.upload(
+                    file={
+                        "file_name": "uploaded_file.pdf",
+                        "content": file_content,
+                    },
+                    purpose="ocr",
+                )
+            # Se realiza la recuperación y firma del archivo subido
+            self.client.files.retrieve(file_id=uploaded_file.id)
+            signed_url = self.client.files.get_signed_url(file_id=uploaded_file.id)
+
+            # Opcional: Procesar el OCR del PDF si se requiere
+            ocr_response = self.client.ocr.process(
+                model="mistral-ocr-latest",
+                document={
+                    "type": "document_url",
+                    "document_url": signed_url.url,
+                },
+                include_image_base64=True,
+            )
+            
+            return signed_url.url
+        except Exception as e:
+            logger.error(f"Error al procesar el PDF {pdf_path}: {e}", exc_info=True)
+            raise e

--- a/services/webhook.py
+++ b/services/webhook.py
@@ -1,0 +1,23 @@
+from config.settings import WEBHOOK_URL
+import requests
+
+class WebhookService:
+    def __init__(self, api_url: str = WEBHOOK_URL):
+        self.api_url = api_url
+
+    def make_message(self, message):
+        #Devolver un json estructurado con el mensaje
+        return f"Estimado equipo, se ha presentado un error en el sistema: {message}"
+    def send_to_webhook(self, data):
+        headers = {
+            'Content-Type': 'application/json'
+        }
+
+        payload = {
+            'text': self.make_message(data)
+        }
+        response = requests.post(self.api_url,  json=payload, headers=headers)
+        if response.status_code != 200:
+            raise ConnectionError(f"Error en la solicitud: {response.status_code} - {response.text}")
+    
+

--- a/utils/file_encoder.py
+++ b/utils/file_encoder.py
@@ -1,0 +1,26 @@
+import base64
+import logging
+from pathlib import Path
+from utils.logger import logger
+
+
+class FileEncoder:
+    @staticmethod
+    def encode_image(image_path: str) -> str:
+        """Codifica una imagen a una cadena en base64.
+
+        :param image_path: Ruta del archivo de imagen.
+        :return: Cadena codificada en base64 o None si ocurre un error.
+        """
+        image_file = Path(image_path)
+        if not image_file.is_file():
+            logger.error(f"Archivo no encontrado: {image_path}")
+            return None
+        
+        try:
+            with open(image_file, "rb") as f:
+                encoded_data = base64.b64encode(f.read()).decode('utf-8')
+            return encoded_data
+        except Exception as e:
+            logger.error(f"Error al codificar la imagen {image_path}: {e}")
+            return None

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,31 @@
+import logging
+import sys
+
+def setup_logger(name: str, level: int = logging.INFO) -> logging.Logger:
+    """
+    Configura y retorna un logger con el nombre y nivel especificados.
+    
+    :param name: Nombre del logger.
+    :param level: Nivel de logging (por defecto, INFO).
+    :return: Instancia de logging.Logger configurada.
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+
+    # Evitar añadir múltiples handlers si ya existen
+    if not logger.handlers:
+        # Crear un handler para la salida en consola
+        console_handler = logging.StreamHandler(sys.stdout)
+        console_handler.setLevel(level)
+
+        # Definir el formato del log
+        formatter = logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        )
+        console_handler.setFormatter(formatter)
+
+        logger.addHandler(console_handler)
+    return logger
+
+# Configuración del logger para el módulo actual
+logger = setup_logger(__name__)

--- a/utils/post_processing/__init__.py
+++ b/utils/post_processing/__init__.py
@@ -1,0 +1,3 @@
+from utils.post_processing.processor import ResponsePostProcessor
+
+__all__ = ['ResponsePostProcessor']

--- a/utils/post_processing/country_processors/__init__.py
+++ b/utils/post_processing/country_processors/__init__.py
@@ -1,0 +1,90 @@
+import re
+from typing import Dict, Any, Optional
+
+from utils.logger import logger
+from utils.post_processing.country_processors.base_processor import CountryProcessor
+from utils.post_processing.country_processors.colombia_processor import ColombiaProcessor
+from utils.post_processing.country_processors.panama_processor import PanamaProcessor
+from utils.post_processing.country_processors.argentina_processor import ArgentinaProcessor
+from utils.post_processing.country_processors.peru_processor import PeruProcessor
+
+# Registro de procesadores disponibles
+_PROCESSORS = {
+    'colombia': ColombiaProcessor(),
+    'panama': PanamaProcessor(),
+    'argentina': ArgentinaProcessor(),
+    'peru': PeruProcessor()
+}
+
+def get_country_processor(country: str) -> Optional[CountryProcessor]:
+    """
+    Retorna el procesador específico para el país indicado
+    
+    Args:
+        country: Nombre del país (en minúsculas)
+        
+    Returns:
+        Instancia del procesador específico o None si no hay coincidencia
+    """
+    if not country:
+        return None
+        
+    for key, processor in _PROCESSORS.items():
+        if key in country:
+            return processor
+    return None
+
+def detect_country(data: Dict[str, Any], ocr_markdown: str = "") -> Optional[str]:
+    """
+    Detecta el país basado en patrones de identificación
+    
+    Args:
+        data: Datos del documento
+        ocr_markdown: Texto OCR original
+        
+    Returns:
+        Nombre del país detectado o None si no se puede determinar
+    """
+    tax_info = data.get('tax_information', {})
+    tax_id = tax_info.get('tax_identification_number', '')
+    
+    # Patrones para Colombia: NIT con dígito de verificación
+    if re.search(r'\d{9,10}-\d{1}', tax_id) or re.search(r'\d{1,3}\.\d{3}\.\d{3}-\d{1}', tax_id):
+        logger.info("Patrón de NIT colombiano detectado por formato")
+        return "Colombia"
+    
+    # Patrones para Panamá: ID con formato X-XXX-XXXX
+    elif re.search(r'\d{1,2}-\d{3,4}-\d{3,4}', tax_id):
+        logger.info("Patrón de identificación panameña detectado por formato")
+        return "Panama"
+    
+    # Patrones para Argentina: CUIT/CUIL con formato XX-XXXXXXXX-X
+    elif re.search(r'\d{2}-\d{8}-\d{1}', tax_id):
+        logger.info("Patrón de CUIT/CUIL argentino detectado por formato")
+        return "Argentina"
+    
+    # Patrones para Perú: RUC siempre tiene 11 dígitos
+    elif tax_id and len(tax_id) == 11:
+        logger.info("Posible RUC peruano detectado por longitud (11 dígitos)")
+        return "Peru"
+    
+    # Si no se detecta por los datos, intentar inferir del OCR
+    elif ocr_markdown:
+        # Buscar patrones específicos de países en el OCR
+        if re.search(r'NIT|DIAN|Colombia|Colombiana|Bogot[aá]|Medell[ií]n|Cali', ocr_markdown, re.IGNORECASE):
+            logger.info("País Colombia detectado por OCR")
+            return "Colombia"
+        
+        elif re.search(r'RUC|Panam[aá]|Ciudad de Panam[aá]|Panamanian', ocr_markdown, re.IGNORECASE):
+            logger.info("País Panamá detectado por OCR")
+            return "Panama"
+        
+        elif re.search(r'CUIT|CUIL|AFIP|Argentina|Buenos Aires|Mendoza|C[oó]rdoba', ocr_markdown, re.IGNORECASE):
+            logger.info("País Argentina detectado por OCR")
+            return "Argentina"
+        
+        elif re.search(r'RUC|Per[uú]|SUNAT|Lima|Arequipa|Trujillo', ocr_markdown, re.IGNORECASE):
+            logger.info("País Perú detectado por OCR")
+            return "Peru"
+    
+    return None

--- a/utils/post_processing/country_processors/argentina_processor.py
+++ b/utils/post_processing/country_processors/argentina_processor.py
@@ -1,0 +1,68 @@
+import re
+from typing import Dict, Any
+from utils.logger import logger
+from utils.post_processing.country_processors.base_processor import CountryProcessor
+
+class ArgentinaProcessor(CountryProcessor):
+    """Procesador específico para documentos argentinos"""
+    
+    @classmethod
+    def get_country_name(cls) -> str:
+        return "argentina"
+    
+    def process(self, data: Dict[str, Any], ocr_markdown: str = "") -> None:
+        """Procesa y corrige datos específicos para Argentina"""
+        tax_info = data.get('tax_information', {})
+        
+        # Ajustar tipo de documento, CUIT para empresas, CUIL para personas
+        self._set_document_type(data, tax_info)
+        
+        # Procesar CUIT/CUIL argentino
+        self._process_cuit_cuil(tax_info)
+        
+        # Establecer tax_office específico para Argentina
+        if not tax_info.get('tax_office'):
+            tax_info['tax_office'] = "Administración Federal de Ingresos Públicos"
+        
+        # Corregir document_type para representante legal
+        self._process_representative(data)
+    
+    def _set_document_type(self, data: Dict[str, Any], tax_info: Dict[str, Any]) -> None:
+        """Establece el tipo de documento para Argentina"""
+        company_name = data.get('company_information', {}).get('legal_name', '')
+        if company_name:
+            tax_info['tax_document_type'] = 'CUIT'
+        elif not tax_info.get('tax_document_type') or tax_info.get('tax_document_type') == '':
+            tax_info['tax_document_type'] = 'CUIT'  # Por defecto para documentos fiscales
+    
+    def _process_cuit_cuil(self, tax_info: Dict[str, Any]) -> None:
+        """Procesa el CUIT/CUIL argentino"""
+        tax_id = tax_info.get('tax_identification_number', '')
+        
+        # Verificar formato con guiones (XX-XXXXXXXX-X)
+        cuit_pattern = re.search(r'(\d{2})-(\d{8})-(\d{1})', tax_id)
+        if cuit_pattern:
+            part1, part2, part3 = cuit_pattern.groups()
+            tax_info['verification_digit'] = part3
+            tax_info['tax_identification_number'] = f"{part1}{part2}"
+            logger.info(f"CUIT/CUIL argentino procesado: Base={part1}{part2}, DV={part3}")
+        
+        # Si ya tenemos un CUIT/CUIL de 11 dígitos sin guiones
+        elif tax_id and len(tax_id) == 11:
+            if not tax_info.get('verification_digit'):
+                tax_info['verification_digit'] = tax_id[-1]
+            tax_info['tax_identification_number'] = tax_id[:-1]
+            logger.info(f"CUIT/CUIL argentino corregido: separando DV={tax_id[-1]}")
+    
+    def _process_representative(self, data: Dict[str, Any]) -> None:
+        """Procesa los datos del representante legal"""
+        legal_rep = data.get('legal_representative', {})
+        if legal_rep:
+            if not legal_rep.get('document_type') or legal_rep.get('document_type') == '':
+                legal_rep['document_type'] = 'DNI'
+            
+            # Si el representante legal también tiene CUIT/CUIL, aplicar la misma lógica
+            if legal_rep.get('document_type') in ['CUIT', 'CUIL'] and legal_rep.get('document_number'):
+                doc_number = legal_rep.get('document_number')
+                if len(doc_number) == 11:
+                    legal_rep['document_number'] = doc_number[:-1]

--- a/utils/post_processing/country_processors/base_processor.py
+++ b/utils/post_processing/country_processors/base_processor.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+
+class CountryProcessor(ABC):
+    """Clase base abstracta para procesadores específicos de cada país"""
+    
+    @abstractmethod
+    def process(self, data: Dict[str, Any], ocr_markdown: str = "") -> None:
+        """Procesa y corrige datos específicos del país"""
+        pass
+    
+    @classmethod
+    def get_country_name(cls) -> str:
+        """Retorna el nombre del país que maneja este procesador"""
+        pass

--- a/utils/post_processing/country_processors/colombia_processor.py
+++ b/utils/post_processing/country_processors/colombia_processor.py
@@ -1,0 +1,67 @@
+import re
+from typing import Dict, Any
+from utils.logger import logger
+from utils.post_processing.country_processors.base_processor import CountryProcessor
+
+class ColombiaProcessor(CountryProcessor):
+    """Procesador específico para documentos colombianos"""
+    
+    @classmethod
+    def get_country_name(cls) -> str:
+        return "colombia"
+    
+    def process(self, data: Dict[str, Any], ocr_markdown: str = "") -> None:
+        """Procesa y corrige datos específicos para Colombia"""
+        tax_info = data.get('tax_information', {})
+        
+        # Corregir tax_document_type (siempre NIT para empresas, CC para personas)
+        self._set_document_type(data, tax_info)
+        
+        # Procesar NIT y dígito verificador
+        self._process_nit(tax_info)
+        
+        # Establecer tax_office específico para Colombia
+        if not tax_info.get('tax_office'):
+            tax_info['tax_office'] = "Dirección de Impuestos y Aduanas Nacionales"
+        
+        # Corregir document_type para representante legal
+        self._process_representative(data)
+    
+    def _set_document_type(self, data: Dict[str, Any], tax_info: Dict[str, Any]) -> None:
+        """Establece el tipo de documento para Colombia"""
+        company_name = data.get('company_information', {}).get('legal_name', '')
+        if company_name:
+            tax_info['tax_document_type'] = 'NIT'
+        elif not tax_info.get('tax_document_type'):
+            tax_info['tax_document_type'] = 'NIT'  # Por defecto para documentos fiscales
+    
+    def _process_nit(self, tax_info: Dict[str, Any]) -> None:
+        """Procesa el NIT colombiano y extrae el dígito verificador"""
+        tax_id = tax_info.get('tax_identification_number', '')
+        
+        # Buscar patrones de NIT con punto y guión (900.123.456-7)
+        nit_pattern = re.search(r'(\d{1,3}(?:\.\d{3}){2})-(\d{1})', tax_id)
+        if nit_pattern:
+            # Extraer componentes del NIT
+            base, dv = nit_pattern.groups()
+            # Configurar verification_digit
+            tax_info['verification_digit'] = dv
+            # Actualizar tax_identification_number sin puntos ni guiones
+            tax_info['tax_identification_number'] = re.sub(r'[^0-9]', '', base)
+            logger.info(f"NIT colombiano procesado: Base={re.sub(r'[^0-9]', '', base)}, DV={dv}")
+        
+        # Buscar patrones de NIT sin puntos pero con guión (900123456-7)
+        elif '-' in tax_id:
+            parts = tax_id.split('-')
+            if len(parts) == 2 and parts[1].isdigit() and len(parts[1]) == 1:
+                tax_info['verification_digit'] = parts[1]
+                tax_info['tax_identification_number'] = parts[0].replace('.', '').replace(' ', '')
+                logger.info(f"NIT colombiano con guión procesado: Base={parts[0]}, DV={parts[1]}")
+    
+    def _process_representative(self, data: Dict[str, Any]) -> None:
+        """Procesa los datos del representante legal"""
+        legal_rep = data.get('legal_representative', {})
+        if legal_rep:
+            if not legal_rep.get('document_type') or legal_rep.get('document_type') == '':
+                legal_rep['document_type'] = 'CC'
+                logger.info("Asignado tipo de documento 'CC' por defecto al representante legal")

--- a/utils/post_processing/country_processors/panama_processor.py
+++ b/utils/post_processing/country_processors/panama_processor.py
@@ -1,0 +1,48 @@
+import re
+from typing import Dict, Any
+from utils.logger import logger
+from utils.post_processing.country_processors.base_processor import CountryProcessor
+
+class PanamaProcessor(CountryProcessor):
+    """Procesador específico para documentos panameños"""
+    
+    @classmethod
+    def get_country_name(cls) -> str:
+        return "panama"
+    
+    def process(self, data: Dict[str, Any], ocr_markdown: str = "") -> None:
+        """Procesa y corrige datos específicos para Panamá"""
+        tax_info = data.get('tax_information', {})
+        
+        # Siempre usar RUC para documentos fiscales en Panamá
+        if not tax_info.get('tax_document_type') or tax_info.get('tax_document_type') == '':
+            tax_info['tax_document_type'] = 'RUC'
+            logger.info("Asignado tipo de documento 'RUC' por defecto")
+        
+        # Procesar identificación panameña (formato X-XXX-XXXX)
+        self._process_ruc(tax_info)
+        
+        # Establecer tax_office específico para Panamá
+        if not tax_info.get('tax_office'):
+            tax_info['tax_office'] = "Dirección General de Comercio Interior"
+            logger.info("Asignada oficina de impuestos por defecto para Panamá")
+        
+        # Corregir document_type para representante legal
+        self._process_representative(data)
+    
+    def _process_ruc(self, tax_info: Dict[str, Any]) -> None:
+        """Procesa el RUC panameño"""
+        tax_id = tax_info.get('tax_identification_number', '')
+        if re.search(r'\d{1,2}-\d{3,4}-\d{3,4}', tax_id):
+            # Ya tenemos el formato correcto, solo eliminamos los guiones
+            clean_id = re.sub(r'[^0-9]', '', tax_id)
+            tax_info['tax_identification_number'] = clean_id
+            logger.info(f"Identificación panameña procesada: {tax_id} → {clean_id}")
+    
+    def _process_representative(self, data: Dict[str, Any]) -> None:
+        """Procesa los datos del representante legal"""
+        legal_rep = data.get('legal_representative', {})
+        if legal_rep:
+            if not legal_rep.get('document_type') or legal_rep.get('document_type') == '':
+                legal_rep['document_type'] = 'CI'
+                logger.info("Asignado tipo de documento 'CI' por defecto al representante legal")

--- a/utils/post_processing/country_processors/peru_processor.py
+++ b/utils/post_processing/country_processors/peru_processor.py
@@ -1,0 +1,47 @@
+import re
+from typing import Dict, Any
+from utils.logger import logger
+from utils.post_processing.country_processors.base_processor import CountryProcessor
+
+class PeruProcessor(CountryProcessor):
+    """Procesador específico para documentos peruanos"""
+    
+    @classmethod
+    def get_country_name(cls) -> str:
+        return "peru"
+    
+    def process(self, data: Dict[str, Any], ocr_markdown: str = "") -> None:
+        """Procesa y corrige datos específicos para Perú"""
+        tax_info = data.get('tax_information', {})
+        
+        # Siempre usar RUC para documentos fiscales en Perú
+        if not tax_info.get('tax_document_type') or tax_info.get('tax_document_type') == '':
+            tax_info['tax_document_type'] = 'RUC'
+            logger.info("Asignado tipo de documento 'RUC' por defecto")
+        
+        # Validar formato RUC
+        self._validate_ruc(tax_info)
+        
+        # Establecer tax_office específico para Perú
+        if not tax_info.get('tax_office'):
+            tax_info['tax_office'] = "Superintendencia Nacional de Aduanas y de Administración Tributaria"
+            logger.info("Asignada oficina de impuestos por defecto para Perú")
+        
+        # Corregir document_type para representante legal
+        self._process_representative(data)
+    
+    def _validate_ruc(self, tax_info: Dict[str, Any]) -> None:
+        """Valida el formato del RUC peruano"""
+        if tax_info.get('tax_document_type') == 'RUC' and tax_info.get('tax_identification_number'):
+            tax_id = re.sub(r'[^0-9]', '', tax_info['tax_identification_number'])
+            if len(tax_id) > 0 and len(tax_id) != 11:
+                logger.warning(f"RUC peruano no tiene 11 dígitos: {tax_id}")
+            tax_info['tax_identification_number'] = tax_id
+    
+    def _process_representative(self, data: Dict[str, Any]) -> None:
+        """Procesa los datos del representante legal"""
+        legal_rep = data.get('legal_representative', {})
+        if legal_rep:
+            if not legal_rep.get('document_type') or legal_rep.get('document_type') == '':
+                legal_rep['document_type'] = 'DNI'
+                logger.info("Asignado tipo de documento 'DNI' por defecto al representante legal")

--- a/utils/post_processing/processor.py
+++ b/utils/post_processing/processor.py
@@ -1,0 +1,90 @@
+import json
+from typing import Dict, Any, Optional
+
+from utils.logger import logger
+from utils.post_processing.country_processors import (
+    get_country_processor,
+    detect_country
+)
+from utils.post_processing.validators import (
+    validate_tax_document,
+    validate_tax_id,
+    validate_person_document
+)
+from utils.post_processing.utils.date_normalizer import normalize_dates
+
+class ResponsePostProcessor:
+    """
+    Clase principal para post-procesar y corregir datos extraídos de documentos fiscales
+    después de la validación fiscal.
+    """
+    
+    @staticmethod
+    def process_response(json_response: str, ocr_markdown: str = "") -> str:
+        """
+        Procesa y corrige la respuesta JSON para asegurar que los datos estén
+        correctamente formateados según las reglas específicas de cada país.
+        
+        Args:
+            json_response: Respuesta JSON original (ya validada por fiscal_validator)
+            ocr_markdown: Texto OCR original para validaciones adicionales
+            
+        Returns:
+            JSON corregido y estandarizado
+        """
+        try:
+            data = json.loads(json_response)
+            
+            # Obtener o detectar el país
+            country = data.get('location', {}).get('country', '').lower()
+            if not country:
+                country = detect_country(data, ocr_markdown)
+                if country:
+                    if 'location' not in data:
+                        data['location'] = {}
+                    data['location']['country'] = country
+            
+            # Obtener el procesador específico para el país
+            country_processor = get_country_processor(country)
+            
+            # Procesar datos específicos del país
+            if country_processor:
+                country_processor.process(data, ocr_markdown)
+            
+            # Aplicar validaciones generales
+            ResponsePostProcessor._apply_general_fixes(data, ocr_markdown)
+            
+            logger.info("Post-procesamiento completado correctamente")
+            return json.dumps(data)
+        
+        except json.JSONDecodeError:
+            logger.error("Error decodificando JSON en el post-procesador")
+            return json_response
+        except Exception as e:
+            logger.error(f"Error en el post-procesamiento: {e}")
+            return json_response
+    
+    @staticmethod
+    def _apply_general_fixes(data: Dict[str, Any], ocr_markdown: str = "") -> None:
+        """Aplica correcciones generales a cualquier documento"""
+        # Validar y corregir los campos críticos
+        tax_info = data.get('tax_information', {})
+        legal_rep = data.get('legal_representative', {})
+        country = data.get('location', {}).get('country', '').lower()
+        
+        # Validar tax_document_type
+        validate_tax_document(tax_info, country, data, ocr_markdown)
+        
+        # Validar tax_identification_number
+        validate_tax_id(tax_info, country, ocr_markdown)
+        
+        # Validar document_type y document_number del representante legal
+        validate_person_document(legal_rep, country, ocr_markdown)
+        
+        # Normalizar formato de fechas
+        normalize_dates(data)
+        
+        # Asegurar que fiscal_document sea booleano
+        if 'fiscal_document' in data and not isinstance(data['fiscal_document'], bool):
+            if isinstance(data['fiscal_document'], str):
+                data['fiscal_document'] = data['fiscal_document'].lower() == 'true'

--- a/utils/post_processing/utils/__init__.py
+++ b/utils/post_processing/utils/__init__.py
@@ -1,0 +1,8 @@
+# Exportar utilidades específicas
+from utils.post_processing.utils.date_normalizer import normalize_dates
+from utils.post_processing.utils.ocr_extractor import extract_tax_id_from_ocr
+
+__all__ = [
+    'normalize_dates',
+    'extract_tax_id_from_ocr'
+]

--- a/utils/post_processing/utils/date_normalizer.py
+++ b/utils/post_processing/utils/date_normalizer.py
@@ -1,0 +1,54 @@
+import re
+from typing import Dict, Any
+
+def normalize_dates(data: Dict[str, Any]) -> None:
+    """
+    Normaliza todas las fechas al formato YYYY-MM-DD
+    
+    Args:
+        data: Datos del documento con fechas a normalizar
+    """
+    # Patrones comunes de fechas
+    date_patterns = [
+        # DD/MM/YYYY
+        (r'(\d{1,2})/(\d{1,2})/(\d{4})', lambda m: f"{m.group(3)}-{m.group(2).zfill(2)}-{m.group(1).zfill(2)}"),
+        # MM/DD/YYYY
+        (r'(\d{1,2})/(\d{1,2})/(\d{4})', lambda m: f"{m.group(3)}-{m.group(1).zfill(2)}-{m.group(2).zfill(2)}"),
+        # DD-MM-YYYY
+        (r'(\d{1,2})-(\d{1,2})-(\d{4})', lambda m: f"{m.group(3)}-{m.group(2).zfill(2)}-{m.group(1).zfill(2)}"),
+        # YYYY/MM/DD
+        (r'(\d{4})/(\d{1,2})/(\d{1,2})', lambda m: f"{m.group(1)}-{m.group(2).zfill(2)}-{m.group(3).zfill(2)}"),
+        # MM-YYYY (convertir a YYYY-MM-01)
+        (r'(\d{1,2})-(\d{4})', lambda m: f"{m.group(2)}-{m.group(1).zfill(2)}-01"),
+    ]
+    
+    # Campos que contienen fechas
+    date_fields = [
+        ['registration', 'registration_date'],
+        ['registration', 'last_update'],
+        ['company_information', 'economic_activity', 'primary', 'start_date'],
+        ['company_information', 'economic_activity', 'secondary', 'start_date'],
+        ['legal_representative', 'representation_start_date']
+    ]
+    
+    # Normalizar cada campo de fecha
+    for path in date_fields:
+        _normalize_date_field(data, path, date_patterns)
+
+def _normalize_date_field(data: Dict[str, Any], path: list, patterns: list) -> None:
+    """Normaliza un campo de fecha específico"""
+    current = data
+    for i, key in enumerate(path):
+        if i == len(path) - 1:
+            # Llegamos al campo de fecha
+            date_value = current.get(key, '')
+            if date_value and isinstance(date_value, str):
+                # Aplicar patrones de normalización
+                for pattern, replacement in patterns:
+                    if re.match(pattern, date_value):
+                        current[key] = re.sub(pattern, replacement, date_value)
+                        break
+        elif key in current:
+            current = current[key]
+        else:
+            break

--- a/utils/post_processing/utils/ocr_extractor.py
+++ b/utils/post_processing/utils/ocr_extractor.py
@@ -1,0 +1,101 @@
+import re
+from typing import Optional
+from utils.logger import logger
+
+def extract_tax_id_from_ocr(doc_type: str, country: str, ocr_markdown: str) -> Optional[str]:
+    """
+    Extrae el número de identificación fiscal del texto OCR
+    
+    Args:
+        doc_type: Tipo de documento fiscal
+        country: País del documento
+        ocr_markdown: Texto OCR para extraer información
+        
+    Returns:
+        Número de identificación fiscal extraído o None si no se encuentra
+    """
+    if not ocr_markdown:
+        return None
+    
+    # Patrones específicos por tipo de documento y país
+    if 'colombia' in country:
+        if doc_type == 'NIT':
+            # Buscar patrones de NIT en el OCR
+            nit_patterns = [
+                r'NIT\s*:?\s*(\d{1,3}[\.,]?\d{3}[\.,]?\d{3}[-]?\d?)',
+                r'N\.?I\.?T\.?\s*:?\s*(\d{1,3}[\.,]?\d{3}[\.,]?\d{3}[-]?\d?)',
+                r'(?:Número|Numero)?\s*(?:de)?\s*(?:Identificación|Identificacion)?\s*(?:Tributaria?)?:?\s*(\d{1,3}[\.,]?\d{3}[\.,]?\d{3}[-]?\d?)'
+            ]
+            
+            for pattern in nit_patterns:
+                match = re.search(pattern, ocr_markdown, re.IGNORECASE)
+                if match:
+                    return match.group(1)
+    
+    elif 'panama' in country or 'panamá' in country:
+        if doc_type == 'RUC':
+            # Buscar patrones de RUC panameño
+            ruc_patterns = [
+                r'RUC\s*:?\s*(\d{1,2}[-]?\d{3,4}[-]?\d{3,4})',
+                r'R\.?U\.?C\.?\s*:?\s*(\d{1,2}[-]?\d{3,4}[-]?\d{3,4})',
+                r'Registro\s+[ÚúUu]nico\s+(?:de)?\s*Contribuyente\s*:?\s*(\d{1,2}[-]?\d{3,4}[-]?\d{3,4})'
+            ]
+            
+            for pattern in ruc_patterns:
+                match = re.search(pattern, ocr_markdown, re.IGNORECASE)
+                if match:
+                    return match.group(1)
+    
+    elif 'argentina' in country:
+        if doc_type == 'CUIT' or doc_type == 'CUIL':
+            # Buscar patrones de CUIT/CUIL argentino
+            cuit_patterns = [
+                r'CUIT\s*:?\s*(\d{2}[-]?\d{8}[-]?\d{1})',
+                r'CUIL\s*:?\s*(\d{2}[-]?\d{8}[-]?\d{1})',
+                r'C\.?U\.?I\.?T\.?\s*:?\s*(\d{2}[-]?\d{8}[-]?\d{1})',
+                r'C\.?U\.?I\.?L\.?\s*:?\s*(\d{2}[-]?\d{8}[-]?\d{1})'
+            ]
+            
+            for pattern in cuit_patterns:
+                match = re.search(pattern, ocr_markdown, re.IGNORECASE)
+                if match:
+                    return match.group(1)
+    
+    elif 'peru' in country or 'perú' in country:
+        if doc_type == 'RUC':
+            # Buscar patrones de RUC peruano
+            ruc_patterns = [
+                r'RUC\s*:?\s*(\d{11})',
+                r'R\.?U\.?C\.?\s*:?\s*(\d{11})',
+                r'Registro\s+[ÚúUu]nico\s+(?:de)?\s*Contribuyente\s*:?\s*(\d{11})'
+            ]
+            
+            for pattern in ruc_patterns:
+                match = re.search(pattern, ocr_markdown, re.IGNORECASE)
+                if match:
+                    return match.group(1)
+                    
+    # Si llegamos aquí, buscar cualquier secuencia de números que pueda ser un ID fiscal
+    # en función del país y el tipo de documento
+    if 'colombia' in country and doc_type == 'NIT':
+        # NIT sin formato específico (9-10 dígitos)
+        general_match = re.search(r'(\d{9,10})', ocr_markdown)
+        if general_match:
+            logger.info(f"Posible NIT colombiano encontrado por patrón general: {general_match.group(1)}")
+            return general_match.group(1)
+            
+    elif 'argentina' in country and (doc_type == 'CUIT' or doc_type == 'CUIL'):
+        # CUIT/CUIL sin formato específico (11 dígitos)
+        general_match = re.search(r'(\d{11})', ocr_markdown)
+        if general_match:
+            logger.info(f"Posible CUIT/CUIL argentino encontrado por patrón general: {general_match.group(1)}")
+            return general_match.group(1)
+            
+    elif 'peru' in country and doc_type == 'RUC':
+        # RUC sin formato específico (11 dígitos)
+        general_match = re.search(r'(\d{11})', ocr_markdown)
+        if general_match:
+            logger.info(f"Posible RUC peruano encontrado por patrón general: {general_match.group(1)}")
+            return general_match.group(1)
+    
+    return None

--- a/utils/post_processing/validators/__init__.py
+++ b/utils/post_processing/validators/__init__.py
@@ -1,0 +1,9 @@
+from utils.post_processing.validators.tax_document_validator import validate_tax_document
+from utils.post_processing.validators.tax_id_validator import validate_tax_id
+from utils.post_processing.validators.document_validator import validate_person_document
+
+__all__ = [
+    'validate_tax_document',
+    'validate_tax_id',
+    'validate_person_document'
+]

--- a/utils/post_processing/validators/document_validator.py
+++ b/utils/post_processing/validators/document_validator.py
@@ -1,0 +1,186 @@
+import re
+from typing import Dict, Any
+from utils.logger import logger
+
+def validate_person_document(legal_rep: Dict[str, Any], country: str, ocr_markdown: str = "") -> None:
+    """
+    Valida y corrige el document_type y document_number del representante legal
+    
+    Args:
+        legal_rep: Datos del representante legal
+        country: País del documento
+        ocr_markdown: Texto OCR para extraer información adicional
+    """
+    if not legal_rep:
+        return
+    
+    # Validar document_type
+    validate_document_type(legal_rep, country, ocr_markdown)
+    
+    # Validar document_number
+    validate_document_number(legal_rep, country, ocr_markdown)
+
+def validate_document_type(legal_rep: Dict[str, Any], country: str, ocr_markdown: str = "") -> None:
+    """Valida y corrige el document_type del representante legal"""
+    current_type = legal_rep.get('document_type', '').upper()
+    
+    # Si no hay document_type pero tenemos OCR, intentar extraerlo
+    if not current_type and ocr_markdown:
+        # Patrones para buscar el tipo de documento en el OCR
+        rep_doc_patterns = {
+            'colombia': [
+                (r'(?:Representante|Gerente|Director).*?(?:C\.?C\.?|C[eé]dula).*?(\d{6,12})', 'CC'),
+                (r'(?:Representante|Gerente|Director).*?(?:C\.?E\.?).*?(\d{6,12})', 'CE'),
+                (r'(?:Representante|Gerente|Director).*?(?:Pasaporte).*?([A-Z0-9]{6,12})', 'PP')
+            ],
+            'panama': [
+                (r'(?:Representante|Gerente|Director).*?(?:C\.?I\.?|C[eé]dula).*?(\d{1,2}-\d{3,4}-\d{3,4})', 'CI'),
+                (r'(?:Representante|Gerente|Director).*?(?:Pasaporte).*?([A-Z0-9]{6,12})', 'PASAPORTE')
+            ],
+            'argentina': [
+                (r'(?:Representante|Gerente|Director).*?(?:DNI).*?(\d{7,8})', 'DNI'),
+                (r'(?:Representante|Gerente|Director).*?(?:CUIT|CUIL).*?(\d{2}-\d{8}-\d{1})', 'CUIT')
+            ],
+            'peru': [
+                (r'(?:Representante|Gerente|Director).*?(?:DNI).*?(\d{8})', 'DNI'),
+                (r'(?:Representante|Gerente|Director).*?(?:CE).*?([A-Z0-9]{9,12})', 'CE')
+            ]
+        }
+        
+        # Buscar patrones en el OCR para el país detectado
+        for c, patterns in rep_doc_patterns.items():
+            if c in country:
+                for pattern, doc_type in patterns:
+                    match = re.search(pattern, ocr_markdown, re.IGNORECASE)
+                    if match:
+                        current_type = doc_type
+                        # Si encontramos también el número, guardarlo
+                        legal_rep['document_number'] = match.group(1)
+                        logger.info(f"Tipo de documento '{doc_type}' y número '{match.group(1)}' del representante legal detectados por OCR")
+                        break
+                
+                if current_type:
+                    break
+    
+    # Si aún no hay tipo de documento, asignar valor por defecto según el país
+    if not current_type:
+        # Asignar valor por defecto según el país
+        if 'colombia' in country:
+            legal_rep['document_type'] = 'CC'
+            logger.info("Asignando document_type por defecto para Colombia: CC")
+        elif 'panama' in country or 'panamá' in country:
+            legal_rep['document_type'] = 'CI'
+            logger.info("Asignando document_type por defecto para Panamá: CI")
+        elif 'argentina' in country:
+            legal_rep['document_type'] = 'DNI'
+            logger.info("Asignando document_type por defecto para Argentina: DNI")
+        elif 'peru' in country or 'perú' in country:
+            legal_rep['document_type'] = 'DNI'
+            logger.info("Asignando document_type por defecto para Perú: DNI")
+        return
+        
+    # Lista de tipos válidos por país
+    valid_types = {
+        'colombia': ['CC', 'CE', 'TI', 'PP'],
+        'panama': ['CI', 'RUC', 'PASAPORTE'],
+        'argentina': ['DNI', 'CUIT', 'CUIL', 'LE', 'LC'],
+        'peru': ['DNI', 'CE', 'PTP']
+    }
+    
+    # Determinar el país para aplicar reglas
+    target_country = None
+    for c in valid_types.keys():
+        if c in country:
+            target_country = c
+            break
+    
+    if not target_country:
+        return  # No podemos determinar el país
+        
+    # Verificar si el tipo actual es válido, si no, corregirlo
+    if current_type not in valid_types[target_country]:
+        # Usar el tipo predeterminado para el país
+        default_types = {
+            'colombia': 'CC',
+            'panama': 'CI',
+            'argentina': 'DNI',
+            'peru': 'DNI'
+        }
+        correct_type = default_types[target_country]
+        logger.info(f"Corrigiendo document_type de '{current_type}' a '{correct_type}'")
+        legal_rep['document_type'] = correct_type
+    else:
+        legal_rep['document_type'] = current_type
+
+def validate_document_number(legal_rep: Dict[str, Any], country: str, ocr_markdown: str = "") -> None:
+    """Valida y corrige el document_number del representante legal"""
+    doc_number = legal_rep.get('document_number', '')
+    doc_type = legal_rep.get('document_type', '').upper()
+    
+    # Si no hay document_number pero tenemos OCR y doc_type, intentar extraerlo
+    if not doc_number and ocr_markdown and doc_type:
+        # Patrones para buscar el número de documento en el OCR según el tipo
+        rep_num_patterns = {
+            'CC': r'(?:Representante|Gerente|Director).*?(?:C\.?C\.?|C[eé]dula).*?(?:No\.?|Numero|Número)?:?\s*(\d{6,12})',
+            'CE': r'(?:Representante|Gerente|Director).*?(?:C\.?E\.?).*?(?:No\.?|Numero|Número)?:?\s*(\d{6,12})',
+            'TI': r'(?:Representante|Gerente|Director).*?(?:T\.?I\.?).*?(?:No\.?|Numero|Número)?:?\s*(\d{6,12})',
+            'PP': r'(?:Representante|Gerente|Director).*?(?:Pasaporte).*?(?:No\.?|Numero|Número)?:?\s*([A-Z0-9]{6,12})',
+            'CI': r'(?:Representante|Gerente|Director).*?(?:C\.?I\.?|C[eé]dula).*?(?:No\.?|Numero|Número)?:?\s*(\d{1,2}-\d{3,4}-\d{3,4}|\d{5,12})',
+            'DNI': r'(?:Representante|Gerente|Director).*?(?:DNI).*?(?:No\.?|Numero|Número)?:?\s*(\d{7,8})',
+            'CUIT': r'(?:Representante|Gerente|Director).*?(?:CUIT).*?(?:No\.?|Numero|Número)?:?\s*(\d{2}-\d{8}-\d{1}|\d{11})',
+            'CUIL': r'(?:Representante|Gerente|Director).*?(?:CUIL).*?(?:No\.?|Numero|Número)?:?\s*(\d{2}-\d{8}-\d{1}|\d{11})'
+        }
+        
+        if doc_type in rep_num_patterns:
+            pattern = rep_num_patterns[doc_type]
+            match = re.search(pattern, ocr_markdown, re.IGNORECASE)
+            if match:
+                doc_number = match.group(1)
+                legal_rep['document_number'] = doc_number
+                logger.info(f"Número de documento del representante legal detectado por OCR: {doc_number}")
+    
+    # Si aún no hay documento, terminar
+    if not doc_number:
+        return
+        
+    # Limpiar caracteres no numéricos (excepto para pasaportes)
+    if doc_type != 'PP' and doc_type != 'PASAPORTE':
+        clean_number = re.sub(r'[^0-9]', '', doc_number)
+    else:
+        # Para pasaportes, permitir letras y números, eliminar otros caracteres
+        clean_number = re.sub(r'[^A-Z0-9]', '', doc_number.upper())
+    
+    # Validaciones específicas por país
+    if 'colombia' in country:
+        # Cédula colombiana generalmente tiene entre 8 y 10 dígitos
+        if doc_type == 'CC' and (len(clean_number) < 5 or len(clean_number) > 12):
+            logger.warning(f"Posible número de documento colombiano inválido: {clean_number}, longitud: {len(clean_number)}")
+        
+    elif 'panama' in country or 'panamá' in country:
+        # CI panameña generalmente sigue el formato X-XXX-XXXX
+        if doc_type == 'CI':
+            if '-' in doc_number:
+                # Si tenía guiones, verificar que la limpieza los eliminó correctamente
+                if doc_number.replace('-', '') != clean_number:
+                    logger.info(f"Limpiando guiones del documento panameño: {doc_number} → {clean_number}")
+                    
+            # Validar longitud
+            if len(clean_number) < 5 or len(clean_number) > 12:
+                logger.warning(f"Posible número de documento panameño inválido: {clean_number}, longitud: {len(clean_number)}")
+        
+    elif 'argentina' in country:
+        # DNI argentino generalmente tiene entre 7 y 8 dígitos
+        if doc_type == 'DNI' and (len(clean_number) < 7 or len(clean_number) > 9):
+            logger.warning(f"Posible número de documento argentino inválido: {clean_number}, longitud: {len(clean_number)}")
+        
+        # CUIT/CUIL debe tener 11 dígitos
+        elif (doc_type == 'CUIT' or doc_type == 'CUIL') and len(clean_number) != 11:
+            logger.warning(f"CUIT/CUIL debería tener 11 dígitos, encontrado: {len(clean_number)}")
+        
+    elif 'peru' in country or 'perú' in country:
+        # DNI peruano tiene 8 dígitos
+        if doc_type == 'DNI' and len(clean_number) != 8:
+            logger.warning(f"DNI peruano debería tener 8 dígitos, encontrado: {len(clean_number)}")
+    
+    # Actualizar con el número limpio
+    legal_rep['document_number'] = clean_number

--- a/utils/post_processing/validators/fiscal_validator.py
+++ b/utils/post_processing/validators/fiscal_validator.py
@@ -1,0 +1,100 @@
+import json
+import re
+from typing import Dict, Any
+from utils.logger import logger
+
+
+class FiscalDocumentValidator:
+    def __init__(self):
+        # Country-specific regex patterns for fiscal identifiers
+        self.patterns = {
+            "colombia": {
+                "nit": r'\b\d{9,10}[-\s]?\d?\b',  # NIT pattern with optional verification digit
+                "rut": r'\bRUT\b|Registro\s+[Úú]nico\s+Tributario',
+                "dian": r'\bDIAN\b|Direcci[óo]n\s+de\s+Impuestos\s+y\s+Aduanas'
+            },
+            "panama": {
+                "id": r'\b\d{1,2}[-\s]\d{3,4}[-\s]\d{3,4}\b',  # Panamá ID format: X-XXX-XXXX
+                "business": r'PanamaEmprende|Aviso\s+de\s+Operaci[óo]n|establecimiento\s+comercial'
+            },
+            "argentina": {
+                "cuit": r'\b\d{2}[-\s]\d{8}[-\s]\d{1}\b',  # CUIT/CUIL format: XX-XXXXXXXX-X
+                "afip": r'\bAFIP\b|Administraci[óo]n\s+Federal\s+de\s+Ingresos\s+P[úu]blicos'
+            },
+            "peru": {
+                "ruc": r'\bRUC\s*[:=]?\s*\d{11}\b',
+                "sunat": r'\bSUNAT\b|Superintendencia\s+Nacional\s+de\s+Aduanas'
+            }
+        }
+    
+    def validate(self, json_response: str, original_text: str) -> str:
+        """
+        Validate if a document classified as non-fiscal might actually be fiscal
+        
+        Args:
+            json_response: The original JSON response string from Mistral
+            original_text: The raw text extracted from the document through OCR
+            
+        Returns:
+            Updated JSON response string with corrected fiscal_document value if needed
+        """
+        try:
+            response_data = json.loads(json_response)
+            print(f"Validating fiscal document with fiscal_document status: {response_data.get('fiscal_document')}")
+            
+            # Only run validation if fiscal_document is false
+            if not response_data.get("fiscal_document"):
+                fiscal_status = self._determine_fiscal_status(original_text, response_data)
+                
+                if fiscal_status:
+                    logger.info("Document reclassified as fiscal by validator")
+                    response_data["fiscal_document"] = True
+                    return json.dumps(response_data)
+            
+            return json_response
+            
+        except json.JSONDecodeError:
+            logger.error("Invalid JSON response - cannot validate fiscal status")
+            return json_response
+    
+    def _determine_fiscal_status(self, text: str, response_data: Dict[str, Any]) -> bool:
+        """Determine if document is fiscal based on text patterns and tax information"""
+        # Get country from location if available
+        country = response_data.get("location", {}).get("country", "").lower()
+        
+        # Check tax ID - if present, strong indicator of fiscal document
+        tax_id = response_data.get("tax_information", {}).get("tax_identification_number")
+        if tax_id and len(tax_id) >= 8:
+            return True
+            
+        # Run country-specific checks
+        if country == "colombia" or self._check_patterns(text, self.patterns["colombia"]):
+            # In Colombia, ANY of these conditions makes it fiscal
+            return (
+                self._check_patterns(text, self.patterns["colombia"]) or
+                "nit" in text.lower() or "rut" in text.lower() or 
+                "dian" in text.lower()
+            )
+            
+        elif country == "panama" or self._check_patterns(text, self.patterns["panama"]):
+            # For Panama, need both ID pattern and business reference
+            patterns = self.patterns["panama"]
+            has_id = bool(re.search(patterns["id"], text))
+            has_business = bool(re.search(patterns["business"], text))
+            return has_id and has_business
+            
+        elif country == "argentina" or self._check_patterns(text, self.patterns["argentina"]):
+            # For Argentina, need CUIT pattern and AFIP reference
+            patterns = self.patterns["argentina"]
+            return bool(re.search(patterns["cuit"], text) and re.search(patterns["afip"], text))
+            
+        elif country == "peru" or self._check_patterns(text, self.patterns["peru"]):
+            # For Peru, need RUC pattern and SUNAT reference
+            patterns = self.patterns["peru"]
+            return bool(re.search(patterns["ruc"], text) and re.search(patterns["sunat"], text))
+            
+        return False
+    
+    def _check_patterns(self, text: str, patterns: Dict[str, str]) -> bool:
+        """Check if any pattern in the dictionary matches the text"""
+        return any(bool(re.search(pattern, text, re.IGNORECASE)) for pattern in patterns.values())

--- a/utils/post_processing/validators/tax_document_validator.py
+++ b/utils/post_processing/validators/tax_document_validator.py
@@ -1,0 +1,117 @@
+import re
+from typing import Dict, Any
+from utils.logger import logger
+
+def validate_tax_document(tax_info: Dict[str, Any], country: str, data: Dict[str, Any], ocr_markdown: str = "") -> None:
+    """
+    Valida y corrige el tax_document_type según reglas específicas por país
+    
+    Args:
+        tax_info: Información fiscal a validar y corregir
+        country: País del documento
+        data: Datos completos del documento
+        ocr_markdown: Texto OCR para extraer información adicional
+    """
+    if not tax_info:
+        return
+        
+    company_name = data.get('company_information', {}).get('legal_name', '')
+    current_type = tax_info.get('tax_document_type', '').upper()
+    
+    # Lista de tipos válidos por país
+    valid_types = {
+        'colombia': ['NIT', 'CC', 'CE', 'TI', 'PP'],
+        'panama': ['RUC', 'CI'],
+        'argentina': ['CUIT', 'CUIL', 'DNI'],
+        'peru': ['RUC', 'DNI']
+    }
+    
+    # Si el tax_document_type está vacío, intentar extraerlo del OCR
+    if not current_type and ocr_markdown:
+        # Patrones para buscar el tipo de documento en el OCR
+        type_patterns = {
+            'colombia': [
+                (r'NIT\s*:?\s*\d', 'NIT'),
+                (r'C[eé]dula\s*de\s*Ciudadan[ií]a', 'CC'),
+                (r'C\.?C\.?\s*:?\s*\d', 'CC'),
+                (r'C[eé]dula\s*de\s*Extranjer[ií]a', 'CE'),
+                (r'C\.?E\.?\s*:?\s*\d', 'CE')
+            ],
+            'panama': [
+                (r'RUC\s*:?\s*\d', 'RUC'),
+                (r'C[eé]dula\s*de\s*Identidad', 'CI'),
+                (r'C\.?I\.?\s*:?\s*\d', 'CI')
+            ],
+            'argentina': [
+                (r'CUIT\s*:?\s*\d', 'CUIT'),
+                (r'CUIL\s*:?\s*\d', 'CUIL'),
+                (r'DNI\s*:?\s*\d', 'DNI')
+            ],
+            'peru': [
+                (r'RUC\s*:?\s*\d', 'RUC'),
+                (r'DNI\s*:?\s*\d', 'DNI')
+            ]
+        }
+        
+        # Buscar patrones en el OCR para el país detectado
+        for c, patterns in type_patterns.items():
+            if c in country:
+                for pattern, doc_type in patterns:
+                    if re.search(pattern, ocr_markdown, re.IGNORECASE):
+                        current_type = doc_type
+                        logger.info(f"Tipo de documento fiscal '{doc_type}' detectado por OCR")
+                        break
+                
+                if current_type:
+                    break
+    
+    # Determinar el país para aplicar reglas
+    target_country = None
+    for c in valid_types.keys():
+        if c in country:
+            target_country = c
+            break
+    
+    if not target_country:
+        return  # No podemos determinar el país
+    
+    # Corrección basada en país y contenido
+    correct_type = None
+    
+    if target_country == 'colombia':
+        # Para Colombia: empresas usan NIT, personas naturales CC
+        if company_name:
+            correct_type = 'NIT'
+        else:
+            # Si no es empresa y el tipo actual no es válido, usar CC por defecto
+            correct_type = current_type if current_type in valid_types['colombia'] else 'CC'
+    
+    elif target_country == 'panama':
+        # Para Panamá: casi siempre es RUC para documentos fiscales
+        correct_type = 'RUC'
+    
+    elif target_country == 'argentina':
+        # Para Argentina: empresas usan CUIT, personas CUIL
+        if company_name:
+            correct_type = 'CUIT'
+        else:
+            # Si no es una empresa, intentar determinar entre CUIL y DNI
+            if current_type in valid_types['argentina']:
+                correct_type = current_type
+            else:
+                correct_type = 'CUIL'  # Por defecto para personas
+    
+    elif target_country == 'peru':
+        # Para Perú: empresas usan RUC, personas DNI
+        if company_name:
+            correct_type = 'RUC'
+        else:
+            correct_type = 'DNI'
+    
+    # Verificar si el tipo actual es válido, si no, corregirlo
+    if current_type not in valid_types[target_country]:
+        logger.info(f"Corrigiendo tax_document_type de '{current_type}' a '{correct_type}'")
+        tax_info['tax_document_type'] = correct_type
+    elif not current_type:
+        logger.info(f"Asignando tax_document_type por defecto: '{correct_type}'")
+        tax_info['tax_document_type'] = correct_type

--- a/utils/post_processing/validators/tax_id_validator.py
+++ b/utils/post_processing/validators/tax_id_validator.py
@@ -1,0 +1,99 @@
+import re
+from typing import Dict, Any
+from utils.logger import logger
+from utils.post_processing.utils.ocr_extractor import extract_tax_id_from_ocr
+
+def validate_tax_id(tax_info: Dict[str, Any], country: str, ocr_markdown: str = "") -> None:
+    """
+    Valida y corrige el tax_identification_number según patrones específicos por país
+    
+    Args:
+        tax_info: Información fiscal a validar y corregir
+        country: País del documento
+        ocr_markdown: Texto OCR para extraer información adicional
+    """
+    if not tax_info:
+        return
+        
+    tax_id = tax_info.get('tax_identification_number', '')
+    doc_type = tax_info.get('tax_document_type', '').upper()
+    
+    # Si no hay tax_id pero tenemos OCR, intentar extraerlo
+    if not tax_id and ocr_markdown:
+        tax_id = extract_tax_id_from_ocr(doc_type, country, ocr_markdown)
+        if tax_id:
+            tax_info['tax_identification_number'] = tax_id
+    
+    # Si no hay tax_id después de buscar en OCR, terminar
+    if not tax_id:
+        return
+        
+    # Eliminar caracteres no numéricos para validación
+    clean_id = re.sub(r'[^0-9]', '', tax_id)
+    
+    # Validaciones específicas por país
+    if 'colombia' in country:
+        _validate_colombia_tax_id(tax_info, doc_type, tax_id, clean_id)
+    elif 'panama' in country or 'panamá' in country:
+        _validate_panama_tax_id(tax_info, tax_id, clean_id)
+    elif 'argentina' in country:
+        _validate_argentina_tax_id(tax_info, doc_type, tax_id, clean_id)
+    elif 'peru' in country or 'perú' in country:
+        _validate_peru_tax_id(tax_info, doc_type, clean_id)
+    
+    # Actualizar con el ID limpio
+    tax_info['tax_identification_number'] = clean_id
+
+def _validate_colombia_tax_id(tax_info: Dict[str, Any], doc_type: str, tax_id: str, clean_id: str) -> None:
+    """Valida y corrige el tax_identification_number para Colombia"""
+    if doc_type == 'NIT':
+        # Verificar DV y formato
+        if len(clean_id) > 10:
+            if not tax_info.get('verification_digit'):
+                tax_info['verification_digit'] = clean_id[-1]
+                tax_info['tax_identification_number'] = clean_id[:-1]
+                logger.info(f"Extrayendo DV del tax_identification_number: {clean_id[:-1]}, DV: {tax_info['verification_digit']}")
+        
+        # Buscar DV en el formato original (ej. 900123456-7)
+        elif '-' in tax_id and not tax_info.get('verification_digit'):
+            parts = tax_id.split('-')
+            if len(parts) == 2 and len(parts[1]) == 1:
+                tax_info['verification_digit'] = parts[1]
+                logger.info(f"DV detectado en formato NIT: {parts[1]}")
+
+def _validate_panama_tax_id(tax_info: Dict[str, Any], tax_id: str, clean_id: str) -> None:
+    """Valida y corrige el tax_identification_number para Panamá"""
+    # RUC panameño puede tener formato variado, pero generalmente
+    # sigue el patrón X-XXX-XXXX o similar con guiones
+    if '-' in tax_id:
+        # Conservar el formato con guiones en el original
+        formatted_id = tax_id
+        logger.info(f"Formato RUC panameño detectado: {formatted_id}, limpio: {clean_id}")
+
+def _validate_argentina_tax_id(tax_info: Dict[str, Any], doc_type: str, tax_id: str, clean_id: str) -> None:
+    """Valida y corrige el tax_identification_number para Argentina"""
+    if doc_type == 'CUIT' or doc_type == 'CUIL':
+        # Si ya tiene 11 dígitos, separar el último como verificador
+        if len(clean_id) == 11:
+            if not tax_info.get('verification_digit'):
+                tax_info['verification_digit'] = clean_id[-1]
+            tax_info['tax_identification_number'] = clean_id[:-1]
+            logger.info(f"Separando dígito verificador del CUIT/CUIL: {clean_id[:-1]}, DV: {clean_id[-1]}")
+            
+        # Buscar DV en el formato original (ej. 20-12345678-9)
+        elif '-' in tax_id and len(tax_id.split('-')) == 3:
+            parts = tax_id.split('-')
+            if len(parts[2]) == 1:
+                tax_info['verification_digit'] = parts[2]
+                tax_info['tax_identification_number'] = parts[0] + parts[1]
+                logger.info(f"DV detectado en formato CUIT/CUIL: {parts[2]}")
+
+def _validate_peru_tax_id(tax_info: Dict[str, Any], doc_type: str, clean_id: str) -> None:
+    """Valida y corrige el tax_identification_number para Perú"""
+    # RUC peruano debe tener 11 dígitos
+    if doc_type == 'RUC' and len(clean_id) != 11 and len(clean_id) > 0:
+        logger.warning(f"RUC peruano con longitud inválida: {len(clean_id)} dígitos")
+        
+    # DNI peruano debe tener 8 dígitos
+    elif doc_type == 'DNI' and len(clean_id) != 8 and len(clean_id) > 0:
+        logger.warning(f"DNI peruano con longitud inválida: {len(clean_id)} dígitos")


### PR DESCRIPTION
- Implement PanamaProcessor to handle tax information and legal representative data for Panama.
- Implement PeruProcessor to manage tax information and legal representative data for Peru.
- Create ResponsePostProcessor to standardize and validate responses based on country-specific rules.
- Introduce utility functions for date normalization and OCR extraction of tax IDs.
- Develop validators for tax documents and identification numbers, ensuring compliance with country-specific formats.
- Enhance logging for better traceability during processing and validation.